### PR TITLE
Add compatibility to req.txt for other OSes than Linux

### DIFF
--- a/req.txt
+++ b/req.txt
@@ -1,4 +1,5 @@
-beautifulsoup
+beautifulsoup4
 requests
-python-html5lib
+python-html5lib; sys_platform == 'Linux'
+html5lib; sys_platform != 'Linux'
 overrides


### PR DESCRIPTION
I had an issues during reqs installation on my macbook so I made some changes to fix that.